### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ else
 endif
 
 cli: lib
-	gcc main.c -o $(CLI) -L. -lccloc
+	gcc main.c -o $(CLI) -L. -lccloc -lpthread
 
 lib: $(OBJS) 
 	ar rcs $(LIB) $^


### PR DESCRIPTION
I was facing below error on ubuntu 20.04 5.15.153.1-microsoft-standard-WSL2

root@hostname:~/ccloc# make -j4
ar rcs libccloc.a obj/ccloc.o obj/langs.o
gcc main.c -o ccloc -L. -lccloc
/usr/bin/ld: ./libccloc.a(ccloc.o): in function `ccloc': ccloc.c:(.text+0x140f): undefined reference to `pthread_create' /usr/bin/ld: ccloc.c:(.text+0x144d): undefined reference to `pthread_join' collect2: error: ld returned 1 exit status
make: *** [Makefile:18: cli] Error 1

added  -lpthread to resolve this